### PR TITLE
Switch config files from YAML to TOML and fix script paths

### DIFF
--- a/scripts/sh/0_run_methods_all.sh
+++ b/scripts/sh/0_run_methods_all.sh
@@ -14,9 +14,9 @@ do
     data_path=${data_folder}/data/${seq_num}
 
     echo "Processing sequence ${seq_num} ... in octomap [origin, w G, w GF]"
-    ${benchmarks_path}/octomap/build/octomap_run ${data_path} ${benchmarks_path}/octomap/assets/config_g.yaml -1
-    ${benchmarks_path}/octomap/build/octomap_run ${data_path} ${benchmarks_path}/octomap/assets/config_fg.yaml -1
-    ${benchmarks_path}/octomap/build/octomap_run ${data_path} ${benchmarks_path}/octomap/assets/config.yaml -1
+    ${benchmarks_path}/octomap/build/octomap_run ${data_path} ${benchmarks_path}/octomap/assets/config_g.toml -1
+    ${benchmarks_path}/octomap/build/octomap_run ${data_path} ${benchmarks_path}/octomap/assets/config_fg.toml -1
+    ${benchmarks_path}/octomap/build/octomap_run ${data_path} ${benchmarks_path}/octomap/assets/config.toml -1
 
     echo "Processing sequence ${seq_num} ... in remover and erasor"
     if [ "${seq_num}" \> "av2" ]; then


### PR DESCRIPTION
The scripts were pointing to YAML configs, but octomap actually expects TOML. That mismatch caused parse errors (like expected '=' but saw ':').

This update switches the config references to TOML and brings things in line with octomap upstream, which uses TOML as the official format.